### PR TITLE
Fix use of source to use field name

### DIFF
--- a/django_restql/mixins.py
+++ b/django_restql/mixins.py
@@ -82,7 +82,7 @@ class DynamicFieldsMixin(object):
             return fields
 
         is_top_retrieve_request = (
-            self.source is None and 
+            self.field_name is None and 
             self.parent is None
         )
         is_top_list_request = (
@@ -104,17 +104,17 @@ class DynamicFieldsMixin(object):
                     raise ValidationError(msg) from None
                     
         elif isinstance(self.parent, ListSerializer):
-            source = self.parent.source
+            field_name = self.parent.field_name
             parent = self.parent.parent
             fields_query = []
             if hasattr(parent, "nested_fields_queries"):
-                fields_query = parent.nested_fields_queries.get(source, None)
+                fields_query = parent.nested_fields_queries.get(field_name, None)
         elif isinstance(self.parent, Serializer):
-            source = self.source
+            field_name = self.field_name
             parent = self.parent
             fields_query = []
             if hasattr(parent, "nested_fields_queries"):
-                fields_query = parent.nested_fields_queries.get(source, None)
+                fields_query = parent.nested_fields_queries.get(field_name, None)
         else:
             # Unkown scenario
             return fields

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -303,6 +303,24 @@ class DataQueryingTests(APITestCase):
             ]
         )
 
+    def test_list_with_aliased_books(self):
+        url = reverse_lazy("course_with_aliased_books-list")
+        
+        response = self.client.get(url + '?query={name, tomes{title}}', format="json")
+
+        self.assertEqual(
+            response.data,
+            [
+                {
+                    "name": "Data Structures",
+                    "tomes": [
+                        {"title": "Advanced Data Structures"},
+                        {"title": "Basic Data Structures"}
+                    ]
+                }
+            ]
+        )
+
 
 
 class DataMutationTests(APITestCase):

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -45,6 +45,13 @@ class CourseWithExcludeKwargSerializer(CourseSerializer):
         pass
 
 
+class CourseWithAliasedBooksSerializer(CourseSerializer):
+    tomes = BookSerializer(source="books", many=True, read_only=True)
+    class Meta:
+        model = Course
+        fields = ['name', 'code', 'tomes']
+
+
 class StudentSerializer(DynamicFieldsMixin, serializers.ModelSerializer):
     course = CourseSerializer(many=False, read_only=True)
     phone_numbers = PhoneSerializer(many=True, read_only=True)

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -8,7 +8,7 @@ from tests.testapp.serializers import (
 	CourseWithFieldsKwargSerializer, CourseWithExcludeKwargSerializer,
 	CourseWithReturnPkkwargSerializer, ReplaceableStudentSerializer,
 	WritableStudentSerializer, WritableCourseSerializer,
-	ReplaceableCourseSerializer
+	ReplaceableCourseSerializer, CourseWithAliasedBooksSerializer
 )
 
 
@@ -36,6 +36,11 @@ class CourseWithFieldsKwargViewSet(viewsets.ModelViewSet):
 
 class CourseWithExcludeKwargViewSet(viewsets.ModelViewSet):
 	serializer_class = CourseWithExcludeKwargSerializer
+	queryset = Course.objects.all()
+
+
+class CourseWithAliasedBooksViewSet(viewsets.ModelViewSet):
+	serializer_class = CourseWithAliasedBooksSerializer
 	queryset = Course.objects.all()
 
 

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -27,6 +27,7 @@ router.register('courses', views.CourseViewSet, base_name='course')
 router.register('courses-with-returnpk-kwarg', views.CourseWithReturnPkkwargViewSet, base_name='course_with_returnpk_kwarg')
 router.register('courses-with-field-kwarg', views.CourseWithFieldsKwargViewSet, base_name='course_with_field_kwarg')
 router.register('courses-with-exclude-kwarg', views.CourseWithExcludeKwargViewSet, base_name='course_with_exclude_kwarg')
+router.register('courses-with-aliased-books', views.CourseWithAliasedBooksViewSet, base_name='course_with_aliased_books')
 router.register('students', views.StudentViewSet, base_name='student')
 
 router.register('writable-courses', views.WritableCourseViewSet, base_name='wcourse')


### PR DESCRIPTION
When figuring out what fields to include on the `DynamicFieldMixin`, it checks against the `source`/parent's `source`. This presents an issue where a serializer is included under an aliased named and the source is passed into the related serializer. This MR swaps from source to `field_name` and provides a test showing the functionality of it. Removing the source change will cause the test to to fail.

I'm unsure if there is an MR template for this or not, will swap if provided. 🙂 