### PR TITLE
Refactor code

### DIFF
--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -61,11 +61,11 @@ def BaseNestedFieldSerializerFactory(*args,
     
         def validate_data_list(self, data, partial=False):
             model = self.parent.Meta.model
-            rel = getattr(model, self.source).rel
+            rel = getattr(model, self.field_name).rel
 
             if isinstance(rel, ManyToOneRel):
                 # ManyToOne Relation
-                field_name = getattr(model, self.source).field.name
+                field_name = getattr(model, self.field_name).field.name
                 # remove field_name to validated fields
                 contain_field = lambda a: a != field_name
                 fields = filter(contain_field, serializer_class.Meta.fields)

--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -60,8 +60,6 @@ def BaseNestedFieldSerializerFactory(*args,
             return validator.run_validation(pks)
     
         def validate_data_list(self, data, partial=False):
-            request = self.context.get('request')
-            context = {"request": request}
             model = self.parent.Meta.model
             rel = getattr(model, self.source).rel
 
@@ -77,7 +75,7 @@ def BaseNestedFieldSerializerFactory(*args,
                     data=data, 
                     many=True, 
                     partial=partial,
-                    context=context
+                    context=self.context
                 )
                 parent_serializer.is_valid(raise_exception=True)
                 serializer_class.Meta.fields = original_fields
@@ -87,7 +85,7 @@ def BaseNestedFieldSerializerFactory(*args,
                     data=data, 
                     many=True, 
                     partial=partial,
-                    context={"request": request}
+                    context=self.context
                 )
                 parent_serializer.is_valid(raise_exception=True)
             return parent_serializer.validated_data
@@ -166,7 +164,6 @@ def BaseNestedFieldSerializerFactory(*args,
 
         def to_internal_value(self, data):
             request = self.context.get('request')
-            context = {"request": request}
             if request.method in ["PUT", "PATCH"]:
                 return self.data_for_update(data)
 
@@ -177,7 +174,7 @@ def BaseNestedFieldSerializerFactory(*args,
                 data=data, 
                 many=True, 
                 partial=self.is_partial,
-                context=context
+                context=self.context
             )
             parent_serializer.is_valid(raise_exception=True)
             return parent_serializer.validated_data
@@ -215,12 +212,10 @@ def BaseNestedFieldSerializerFactory(*args,
             return obj
 
         def validate_data_based_nested(self, data):
-            request = self.context.get("request")
-            context = {"request": request}
             parent_serializer = serializer_class(
                 data=data, 
                 partial=self.is_partial,
-                context=context
+                context=self.context
             )
             parent_serializer.is_valid(raise_exception=True)
             return parent_serializer.validated_data

--- a/django_restql/mixins.py
+++ b/django_restql/mixins.py
@@ -173,36 +173,6 @@ class DynamicFieldsMixin(object):
         return fields
 
 
-class DynamicPerformance(object):
-    select_related = []
-    prefetch_related = []
-
-    def get_queryset(self):
-        request = self.request
-        query = self.serializer_class.get_parsed_query_from_req(request)
-
-        included_fields = []
-        for field in query:
-            if isinstance(field, dict):
-                for field_name in field:
-                    included_fields.append(field_name)
-            else:
-                included_fields.append(field)
-
-        queryset = super().get_queryset()
-
-        if self.select_related:
-            to_select = set(included_fields)\
-                .intersection(set(self.select_related))
-            queryset = queryset.select_related(*to_select)
-        if self.prefetch_related:
-            to_prefetch = set(included_fields)\
-                .intersection(set(self.prefetch_related))
-            queryset = queryset.prefetch_related(*to_prefetch)
-
-        return queryset
-
-
 class NestedCreateMixin(object):
     """ Create Mixin """
     def create_writable_foreignkey_related(self, data):
@@ -566,7 +536,7 @@ class NestedUpdateMixin(object):
             instance,
             fields["foreignkey_related"]["replaceable"]
         )
-        
+
         self.update_writable_foreignkey_related(
             instance,
             fields["foreignkey_related"]["writable"]

--- a/django_restql/mixins.py
+++ b/django_restql/mixins.py
@@ -207,26 +207,22 @@ class NestedCreateMixin(object):
     """ Create Mixin """
     def create_writable_foreignkey_related(self, data):
         # data format {field: {sub_field: value}}
-        request = self.context.get("request")
-        context = {"request": request}
         objs = {}
         for field, value in data.items():
             # Get serializer class for nested field
             SerializerClass = type(self.get_fields()[field])
-            serializer = SerializerClass(data=value, context=context)
+            serializer = SerializerClass(data=value, context=self.context)
             serializer.is_valid()
             obj = serializer.save()
             objs.update({field: obj})
         return objs
 
     def bulk_create_objs(self, field, data):
-        request = self.context.get("request")
-        context = {"request": request}
         model = self.get_fields()[field].child.Meta.model
         SerializerClass = type(self.get_fields()[field].child)
         pks = []
         for values in data:
-            serializer = SerializerClass(data=values, context=context)
+            serializer = SerializerClass(data=values, context=self.context)
             serializer.is_valid()
             obj = serializer.save()
             pks.append(obj.pk)
@@ -357,8 +353,6 @@ class NestedUpdateMixin(object):
 
     def update_writable_foreignkey_related(self, instance, data):
         # data format {field: {sub_field: value}}
-        request = self.context.get("request")
-        context = {"request": request}
         objs = {}
         for field, values in data.items():
             # Get serializer class for nested field
@@ -367,7 +361,7 @@ class NestedUpdateMixin(object):
             serializer = SerializerClass(
                 nested_obj, 
                 data=values, 
-                context=context,
+                context=self.context,
                 partial=self.partial
             )
             serializer.is_valid()
@@ -376,14 +370,11 @@ class NestedUpdateMixin(object):
         return objs
 
     def bulk_create_many_to_many_related(self, field, nested_obj, data):
-        request = self.context.get("request")
-        context = {"request": request}
-
         # Get serializer class for nested field
         SerializerClass = type(self.get_fields()[field].child)
         pks = []
         for values in data:
-            serializer = SerializerClass(data=values, context=context)
+            serializer = SerializerClass(data=values, context=self.context)
             serializer.is_valid()
             obj = serializer.save()
             pks.append(obj.pk)
@@ -391,14 +382,11 @@ class NestedUpdateMixin(object):
         return pks
 
     def bulk_create_many_to_one_related(self, field, nested_obj, data):
-        request = self.context.get("request")
-        context = {"request": request}
-
         # Get serializer class for nested field
         SerializerClass = type(self.get_fields()[field].child)
         pks = []
         for values in data:
-            serializer = SerializerClass(data=values, context=context)
+            serializer = SerializerClass(data=values, context=self.context)
             serializer.is_valid()
             obj = serializer.save()
             pks.append(obj.pk)
@@ -407,8 +395,6 @@ class NestedUpdateMixin(object):
     def bulk_update_many_to_many_related(self, field, nested_obj, data):
         # {pk: {sub_field: values}}
         objs = []
-        request = self.context.get("request")
-        context = {"request": request}
 
         # Get serializer class for nested field
         SerializerClass = type(self.get_fields()[field].child)
@@ -417,7 +403,7 @@ class NestedUpdateMixin(object):
             serializer = SerializerClass(
                 obj, 
                 data=values, 
-                context=context, 
+                context=self.context, 
                 partial=self.partial
             )
             serializer.is_valid()
@@ -428,8 +414,6 @@ class NestedUpdateMixin(object):
     def bulk_update_many_to_one_related(self, field, instance, data):
         # {pk: {sub_field: values}}
         objs = []
-        request = self.context.get("request")
-        context = {"request": request}
 
         # Get serializer class for nested field
         SerializerClass = type(self.get_fields()[field].child)
@@ -442,7 +426,7 @@ class NestedUpdateMixin(object):
             serializer = SerializerClass(
                 obj, 
                 data=values, 
-                context=context, 
+                context=self.context, 
                 partial=self.partial
             )
             serializer.is_valid()
@@ -582,6 +566,7 @@ class NestedUpdateMixin(object):
             instance,
             fields["foreignkey_related"]["replaceable"]
         )
+        
         self.update_writable_foreignkey_related(
             instance,
             fields["foreignkey_related"]["writable"]

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
-from django_restql.mixins import DynamicFieldsMixin
+from django_restql.mixins import DynamicFieldsMixin, DynamicPerformance
 
 from tests.testapp.models import Book, Course, Student
 from tests.testapp.serializers import (
@@ -19,7 +19,9 @@ class BookViewSet(viewsets.ModelViewSet):
 	queryset = Book.objects.all()
 
 
-class CourseViewSet(viewsets.ModelViewSet):
+class CourseViewSet(DynamicPerformance ,viewsets.ModelViewSet):
+	select_related = []
+	prefetch_related = ["books"]
 	serializer_class = CourseSerializer
 	queryset = Course.objects.all()
 

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -1,6 +1,6 @@
 from rest_framework import viewsets
 from rest_framework.response import Response
-from django_restql.mixins import DynamicFieldsMixin, DynamicPerformance
+from django_restql.mixins import DynamicFieldsMixin
 
 from tests.testapp.models import Book, Course, Student
 from tests.testapp.serializers import (
@@ -19,7 +19,7 @@ class BookViewSet(viewsets.ModelViewSet):
 	queryset = Book.objects.all()
 
 
-class CourseViewSet(DynamicPerformance ,viewsets.ModelViewSet):
+class CourseViewSet(viewsets.ModelViewSet):
 	select_related = []
 	prefetch_related = ["books"]
 	serializer_class = CourseSerializer
@@ -58,20 +58,20 @@ class StudentViewSet(viewsets.ModelViewSet):
 
 
 ######### ViewSets For Data Mutations Testing ##########
-class WritableCourseViewSet( viewsets.ModelViewSet):
+class WritableCourseViewSet(viewsets.ModelViewSet):
 	serializer_class = WritableCourseSerializer
 	queryset = Course.objects.all()
 
-class ReplaceableCourseViewSet( viewsets.ModelViewSet):
+class ReplaceableCourseViewSet(viewsets.ModelViewSet):
 	serializer_class = ReplaceableCourseSerializer
 	queryset = Course.objects.all()
 
 
-class ReplaceableStudentViewSet( viewsets.ModelViewSet):
+class ReplaceableStudentViewSet(viewsets.ModelViewSet):
 	serializer_class = ReplaceableStudentSerializer
 	queryset = Student.objects.all()
 
 
-class WritableStudentViewSet( viewsets.ModelViewSet):
+class WritableStudentViewSet(viewsets.ModelViewSet):
 	serializer_class = WritableStudentSerializer
 	queryset = Student.objects.all()

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -20,8 +20,6 @@ class BookViewSet(viewsets.ModelViewSet):
 
 
 class CourseViewSet(viewsets.ModelViewSet):
-	select_related = []
-	prefetch_related = ["books"]
 	serializer_class = CourseSerializer
 	queryset = Course.objects.all()
 


### PR DESCRIPTION
- pass the whole context instead of extracting request and add it to the context
- Makes `has_query_param`, `get_raw_query`, and `get_parsed_query_from_req` class methods so that they can be reused on a view to implement dynamically prefetching and selecting related fields.