### PR TITLE
Make EagerLoadingMixin independent of DynamicFieldsMixin

### DIFF
--- a/django_restql/settings.py
+++ b/django_restql/settings.py
@@ -1,0 +1,109 @@
+"""
+Settings for Django RESTQL are all namespaced in the RESTQL setting.
+For example your project's `settings.py` file might look like this:
+RESTQL = {
+    'QUERY_PARAM_NAME': 'query'
+}
+This module provides the `restql_settings` object, that is used to access
+Django RESTQL settings, checking for user settings first, then falling
+back to the defaults.
+"""
+from django.conf import settings
+from django.test.signals import setting_changed
+from django.utils.module_loading import import_string
+
+
+DEFAULTS = {
+    'QUERY_PARAM_NAME': 'query'
+}
+
+
+# List of settings that may be in string import notation.
+IMPORT_STRINGS = []
+
+
+def perform_import(val, setting_name):
+    """
+    If the given setting is a string import notation,
+    then perform the necessary import or imports.
+    """
+    if val is None:
+        return None
+    elif isinstance(val, str):
+        return import_from_string(val, setting_name)
+    elif isinstance(val, (list, tuple)):
+        return [import_from_string(item, setting_name) for item in val]
+    return val
+
+
+def import_from_string(val, setting_name):
+    """
+    Attempt to import a class from a string representation.
+    """
+    try:
+        return import_string(val)
+    except ImportError as e:
+        msg = (
+            "Could not import '%s' for RESTQL setting '%s'. %s: %s."
+        ) % (val, setting_name, e.__class__.__name__, e)
+        raise ImportError(msg)
+
+
+class RESTQLSettings:
+    """
+    A settings object, that allows RESTQL settings to be accessed as properties.
+    For example:
+        from django_restql.settings import restql_settings
+        print(restql_settings.QUERY_PARAM_NAME)
+    Any setting with string import paths will be automatically resolved
+    and return the class, rather than the string literal.
+    """
+    def __init__(self, user_settings=None, defaults=None, import_strings=None):
+        self.defaults = defaults or DEFAULTS
+        self.import_strings = import_strings or IMPORT_STRINGS
+        self._cached_attrs = set()
+
+    @property
+    def user_settings(self):
+        if not hasattr(self, '_user_settings'):
+            self._user_settings = getattr(settings, 'RESTQL', {})
+        return self._user_settings
+
+    def __getattr__(self, attr):
+        if attr not in self.defaults:
+            raise AttributeError("Invalid RESTQL setting: '%s'" % attr)
+
+        try:
+            # Check if present in user settings
+            val = self.user_settings[attr]
+        except KeyError:
+            # Fall back to defaults
+            val = self.defaults[attr]
+
+        # Coerce import strings into classes
+        if attr in self.import_strings:
+            val = perform_import(val, attr)
+
+        # Cache the result
+        self._cached_attrs.add(attr)
+        setattr(self, attr, val)
+        return val
+
+    def reload(self):
+        for attr in self._cached_attrs:
+            delattr(self, attr)
+        self._cached_attrs.clear()
+        if hasattr(self, '_user_settings'):
+            delattr(self, '_user_settings')
+
+
+restql_settings = RESTQLSettings(None, DEFAULTS, IMPORT_STRINGS)
+
+
+def reload_restql_settings(*args, **kwargs):
+    setting = kwargs['setting']
+    if setting == 'RESTQL':
+        restql_settings.reload()
+
+
+setting_changed.connect(reload_restql_settings)

--- a/docs/index.md
+++ b/docs/index.md
@@ -614,15 +614,11 @@ When prefetching with a `to_attr`, ensure that there are no collisions. Django d
 When prefetching *and* calling `select_related` on a field, Django may error, since the ORM does allow prefetching a selectable field, but not both at the same time.
 
 ### Changing `query` parameter name
-If you don't want to use the name `query` as your parameter, you can inherit `DynamicFieldsMixin` and change it as shown below
-
+If you don't want to use the name `query` as your parameter, you can change it with`QUERY_PARAM_NAME` on settings file e.g 
 ```py
-from django_restql.mixins import DynamicFieldsMixin
-class MyDynamicFieldMixin(DynamicFieldsMixin):
-    query_param_name = "your_favourite_name"
+QUERY_PARAM_NAME = "your_favourite_name"
 ```
-
- Now you can use this Mixin on your serializer and use the name `your_favourite_name` as your parameter. E.g
+ Now you can use the name `your_favourite_name` as your query parameter. E.g
  
  `GET /users/?your_favourite_name={id, username}`
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -616,11 +616,15 @@ When prefetching *and* calling `select_related` on a field, Django may error, si
 ### Changing `query` parameter name
 If you don't want to use the name `query` as your parameter, you can change it with`QUERY_PARAM_NAME` on settings file e.g 
 ```py
-QUERY_PARAM_NAME = "your_favourite_name"
+RESTQL = {
+    'QUERY_PARAM_NAME' = "your_favourite_name"
+}
 ```
  Now you can use the name `your_favourite_name` as your query parameter. E.g
  
  `GET /users/?your_favourite_name={id, username}`
+
+**Note:** Configuration for **django-restql** is all namespaced inside a single Django setting named `RESTQL`.
 
 
 ## Mutating Data


### PR DESCRIPTION
- Introduce `RequestQueryParserMixin` which is used by both `DynamicFieldsMixiin` & `EagerLoadingMixin`
- Make query parameter name configurable through settings file