### PR TITLE
Handle escaping special characters on arguments

### DIFF
--- a/django_restql/parser.py
+++ b/django_restql/parser.py
@@ -26,10 +26,6 @@ class BaseArgument(List):
 class ArgumentWithoutQuotes(BaseArgument):
     grammar = name(), ':', re.compile(r'[^,:"\'\)]+')
 
-    @property
-    def value(self):
-        return self[0]
-
 
 class ArgumentWithSingleQuotes(BaseArgument):
     grammar = name(), ':', "'", re.compile(r'[^\']+'), "'"

--- a/django_restql/parser.py
+++ b/django_restql/parser.py
@@ -17,16 +17,37 @@ class AllFields(str):
     grammar = '*'
 
 
-class Argument(List):
-    grammar = name(), ':', re.compile(r'[^,:\)]+')
+class BaseArgument(List):
+    @property
+    def value(self):
+        return self[0]
+
+
+class ArgumentWithoutQuotes(BaseArgument):
+    grammar = name(), ':', re.compile(r'[^,:"\'\)]+')
 
     @property
     def value(self):
         return self[0]
 
 
+class ArgumentWithSingleQuotes(BaseArgument):
+    grammar = name(), ':', "'", re.compile(r'[^\']+'), "'"
+
+
+class ArgumentWithDoubleQuotes(BaseArgument):
+    grammar = name(), ':', '"', re.compile(r'[^"]+'), '"'
+
+
 class Arguments(List):
-    grammar = optional(csl([Argument],separator=','))
+    grammar = optional(csl(
+        [
+            ArgumentWithoutQuotes, 
+            ArgumentWithSingleQuotes, 
+            ArgumentWithDoubleQuotes
+        ],
+        separator=','
+    ))
 
 
 class ArgumentsBlock(List):

--- a/docs/querying_data.md
+++ b/docs/querying_data.md
@@ -519,6 +519,18 @@ query = (age: 18){
 }
 ```
 Here we have three arguments, `age`, `country` and `city` and their corresponding values.
+*Note:* To escape any special character(including `,:"'`) use single quote `'` or double quote `"`, also if you want to escape double quote use single quote and vice versa. Escaping is very useful if you are dealing with data which contains special characters e.g time, dates, texts etc. below is an example which contains argument with date type.
+
+```
+query = (age: 18, join_date__lt: '2020-04-27T23:02:32Z'){
+    name,
+    age,
+    location(country: Canada, city: Toronto){
+        country,
+        city
+    }
+}
+```
 
 
 ### Filtering with query arguments

--- a/docs/querying_data.md
+++ b/docs/querying_data.md
@@ -519,7 +519,7 @@ query = (age: 18){
 }
 ```
 Here we have three arguments, `age`, `country` and `city` and their corresponding values.
-*Note:* To escape any special character(including `,:"'`) use single quote `'` or double quote `"`, also if you want to escape double quote use single quote and vice versa. Escaping is very useful if you are dealing with data which contains special characters e.g time, dates, texts etc. below is an example which contains argument with date type.
+*Note:* To escape any special character(including `, : " ' {} ()`) use single quote `'` or double quote `"`, also if you want to escape double quote use single quote and vice versa. Escaping is very useful if you are dealing with data containing special characters e.g time, dates, texts etc. below is an example which contains argument with date type.
 
 ```
 query = (age: 18, join_date__lt: '2020-04-27T23:02:32Z'){

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1027,9 +1027,27 @@ class DataQueryingTests(APITestCase):
                 ]
             )
 
-    def test_list_with_arguments(self):
+    def test_list_on_arguments_with_no_quoted_values(self):
         url = reverse_lazy("student-list")
-        response = self.client.get(url + '?query=(name: Yez){name, age, course{name}}', format="json")
+        response = self.client.get(url + '?query=(name: Yezy, age: 20){name, age, course{name}}', format="json")
+
+        self.assertEqual(
+            response.data,
+            []
+        )
+
+    def test_list_on_arguments_with_single_quoted_string_as_value(self):
+        url = reverse_lazy("student-list")
+        response = self.client.get(url + '?query=(name: \'Yezy\', age: \'20\'){name, age, course{name}}', format="json")
+
+        self.assertEqual(
+            response.data,
+            []
+        )
+
+    def test_list_on_arguments_with_double_quoted_string_as_value(self):
+        url = reverse_lazy("student-list")
+        response = self.client.get(url + '?query=(name: "Yezy", age: "20"){name, age, course{name}}', format="json")
 
         self.assertEqual(
             response.data,
@@ -1038,7 +1056,7 @@ class DataQueryingTests(APITestCase):
 
     def test_list_with_nested_arguments(self):
         url = reverse_lazy("student-list")
-        response = self.client.get(url + '?query={name, age, course(code: CS50){name}}', format="json")
+        response = self.client.get(url + '?query={name, age, course(code: "CS50"){name}}', format="json")
 
         self.assertEqual(
             response.data,

--- a/tests/testapp/views.py
+++ b/tests/testapp/views.py
@@ -59,7 +59,11 @@ class CourseWithDynamicSerializerMethodFieldViewSet(viewsets.ModelViewSet):
 class StudentViewSet(viewsets.ModelViewSet):
 	serializer_class = StudentSerializer
 	queryset = Student.objects.all()
-	filter_fields = {'name': ['exact'], 'course__code': ['exact']}
+	filter_fields = {
+		'name': ['exact'],
+		'age': ['exact'],
+		'course__code': ['exact'],
+	}
 
 
 class StudentEagerLoadingViewSet(EagerLoadingMixin, viewsets.ModelViewSet):


### PR DESCRIPTION
Use single quote `'` and double quote `"` to escape special characters including `, : " ' {} ()`