### PR TITLE
🐛 Moved classproperty() decorator to the django.utils.functional

### DIFF
--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -1,6 +1,9 @@
 import copy
 
-from django.utils.decorators import classproperty
+try:
+    from django.utils.decorators import classproperty
+except ImportError:
+    from django.utils.functional import classproperty
 from django.db.models.fields.related import ManyToOneRel
 
 from rest_framework.fields import DictField, ListField, empty


### PR DESCRIPTION
The decorator classproperty was moved to django.utils.functional [here](https://github.com/django/django/pull/11945) and causes an ImportError

`File "....../python3.8/site-packages/django_restql/fields.py", line 3, in <module>
    from django.utils.decorators import classproperty
ImportError: cannot import name 'classproperty' from 'django.utils.decorators' (/path/to/route/python3.8/site-packages/django/utils/decorators.py)`

Django Version: 3.1.7
django-restql Version: 0.11.1
