### PR TITLE
Fix OPTIONS requests returning all fields of nested serializer

### DIFF
--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,5 +1,6 @@
 from django.urls import reverse_lazy
 from rest_framework.test import APITestCase
+import json
 
 from tests.testapp.models import Book, Course, Phone, Student
 
@@ -1125,6 +1126,80 @@ class DataQueryingTests(APITestCase):
         self.assertEqual(
             response.data,
             []
+        )
+
+    def test_options_on_serializer_with_fields_kwarg(self):
+        url = reverse_lazy("course_with_field_kwarg-list")
+        response = self.client.options(url, format="json")
+
+        self.assertEqual(
+            response.data,
+            {
+                "name": "Course With Fields Kwarg List", "description": "",
+                "renders": ["application/json", "text/html"],
+                "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
+                "actions": {
+                    "POST": {
+                        "name": {
+                            "type": "string", "required": True, "read_only": False,
+                            "label": "Name", "max_length": 50
+                        },
+                        "code": {
+                            "type": "string", "required": True, "read_only": False,
+                            "label": "Code", "max_length": 30
+                        },
+                        "books": {
+                            "type": "field", "required": False, "read_only": True, "label": "Books",
+                            "child": {
+                                "type": "nested object", "required": False, "read_only": True,
+                                "children": {
+                                    "title": {
+                                        "type": "string", "required": True, "read_only": False,
+                                        "label": "Title", "max_length": 50
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        )
+
+    def test_options_on_serializer_with_exclude_kwarg(self):
+        url = reverse_lazy("course_with_exclude_kwarg-list")
+        response = self.client.options(url, format="json")
+
+        self.assertEqual(
+            response.data,
+            {
+                "name": "Course With Exclude Kwarg List", "description": "",
+                "renders": ["application/json", "text/html"],
+                "parses": ["application/json", "application/x-www-form-urlencoded", "multipart/form-data"],
+                "actions": {
+                    "POST": {
+                        "name": {
+                            "type": "string", "required": True, "read_only": False,
+                            "label": "Name", "max_length": 50
+                        },
+                        "code": {
+                            "type": "string", "required": True, "read_only": False,
+                            "label": "Code", "max_length": 30
+                        },
+                        "books": {
+                            "type": "field", "required": False, "read_only": True, "label": "Books",
+                            "child": {
+                                "type": "nested object", "required": False, "read_only": True,
+                                "children": {
+                                    "title": {
+                                        "type": "string", "required": True, "read_only": False,
+                                        "label": "Title", "max_length": 50
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
         )
 
 

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -1,6 +1,5 @@
 from django.urls import reverse_lazy
 from rest_framework.test import APITestCase
-import json
 
 from tests.testapp.models import Book, Course, Phone, Student
 


### PR DESCRIPTION
This fixes a bug with OPTIONS request returning all fields of a nested serializer despite excluding some with `fields` or `exclude` kwargs