### PR TITLE
Make DynamicFieldsMixin independent of request

### DIFF
--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -329,8 +329,8 @@ def NestedFieldWraper(*args, **kwargs):
     serializer_class = kwargs["serializer_class"]
 
     serializer_validation_kwargs = {**factory['kwargs']}
-    # TODO: Find all non validation related kwargs to remove(below are just few)
 
+    # TODO: Find all non validation related kwargs to remove(below are just few)
     # Remove non validation related kwargs from `valdation_kwargs`
     non_validation_kwargs = [
         'many', 'data', 'instance', 'context', 'fields',

--- a/django_restql/mixins.py
+++ b/django_restql/mixins.py
@@ -51,11 +51,10 @@ class RequestQueryParserMixin(object):
 
 class QueryArgumentsMixin(RequestQueryParserMixin):
     """Mixin for converting query arguments into query parameters"""
-    @property
-    def parsed_restql_query(self):
-        if self.has_restql_query_param(self.request):
+    def get_parsed_restql_query(self, request):
+        if self.has_restql_query_param(request):
             try:
-                return self.get_parsed_restql_query_from_req(self.request)
+                return self.get_parsed_restql_query_from_req(request)
             except (SyntaxError, QueryFormatError):
                 # Let `DynamicFieldsMixin` handle this for a user
                 # to get a helpful error message
@@ -92,7 +91,7 @@ class QueryArgumentsMixin(RequestQueryParserMixin):
         return query_params
 
     def inject_query_params_in_req(self, request):
-        parsed = self.parsed_restql_query
+        parsed = self.get_parsed_restql_query(request)
 
         # Generate query params from query arguments
         query_params = self.build_query_params(parsed)

--- a/django_restql/parser.py
+++ b/django_restql/parser.py
@@ -123,12 +123,9 @@ class Block(List):
 ParentField.grammar = IncludedField, Block
 
 
-class Parser(object):
-    def __init__(self, query):
-        self._query = query
-
-    def get_parsed(self):
-        parse_tree = parse(self._query, Block)
+class QueryParser(object):
+    def parse(self, query):
+        parse_tree = parse(query, Block)
         return self._transform_block(parse_tree)
 
     def _transform_block(self, block):

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -719,7 +719,7 @@ class DataQueryingTests(APITestCase):
             ]
         )
 
-    def test_list_with_expanded_dynamic_serializer_method_field_without_query(self):
+    def test_list_with_dynamic_serializer_method_field_without_query_this_tests_query_and_parsed_query_kwargs_too(self):
         """
         Test that the DynamicSerializerMethodField works without a query present.
         """
@@ -735,6 +735,10 @@ class DataQueryingTests(APITestCase):
                     "tomes": [
                         {"title": "Advanced Data Structures", "author": "S.Mobit"},
                         {"title": "Basic Data Structures", "author": "S.Mobit"}
+                    ],
+                    "related_books": [
+                        {"title": "Advanced Data Structures"},
+                        {"title": "Basic Data Structures"}
                     ]
                 }
             ]

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -74,14 +74,25 @@ class CourseWithAliasedBooksSerializer(CourseSerializer):
 
 class CourseWithDynamicSerializerMethodField(CourseSerializer):
     tomes = DynamicSerializerMethodField()
+    related_books = DynamicSerializerMethodField()
 
     class Meta:
         model = Course
-        fields = ['name', 'code', 'tomes']
+        fields = ['name', 'code', 'tomes', 'related_books']
 
-    def get_tomes(self, obj, query):
+    def get_tomes(self, obj, parsed_query):
         books = obj.books.all()
-        serializer = BookSerializer(books, query=query, many=True, read_only=True, context=self.context)
+        serializer = BookSerializer(
+            books, parsed_query=parsed_query, many=True, read_only=True
+        )
+        return serializer.data
+
+    def get_related_books(self, obj, parsed_query):
+        books = obj.books.all()
+        query = "{title}"
+        serializer = BookSerializer(
+            books, query=query, many=True, read_only=True
+        )
         return serializer.data
 
 


### PR DESCRIPTION
### The purpose of this PR is to
- Make `DynamicFieldsMixin` independent of request
- Add a way to pass a query string through a `query` kwarg to a serializer
- Add a way to pass a parsed query through a `parsed_query` kwarg