### PR TITLE
Add a way to remove all nested objects at once

### DIFF
--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -16,6 +16,8 @@ from .operations import ADD, CREATE, REMOVE, UPDATE
 CREATE_OPERATIONS = (ADD, CREATE)
 UPDATE_OPERATIONS = (ADD, CREATE, REMOVE, UPDATE)
 
+ALL_RELATED_OBJS = '__all__'
+
 
 class DynamicSerializerMethodField(SerializerMethodField):
     def to_representation(self, value):
@@ -43,6 +45,7 @@ def BaseNestedFieldSerializerFactory(
         *args,
         accept_pk=False,
         accept_pk_only=False,
+        allow_remove_all=False,
         create_ops=CREATE_OPERATIONS,
         update_ops=UPDATE_OPERATIONS,
         serializer_class=None,
@@ -155,6 +158,15 @@ def BaseNestedFieldSerializerFactory(
             )
 
         def validate_remove_list(self, data):
+            if data == ALL_RELATED_OBJS:
+                if allow_remove_all:
+                    return data
+                else:
+                    msg = (
+                        "Usingi `%s` value on `%s` operation is disabled"
+                        % (ALL_RELATED_OBJS, REMOVE)
+                    )
+                    raise ValidationError(msg, code="not_allowed")
             return self.validate_pk_list(data)
 
         def validate_update_list(self, data):

--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -53,15 +53,24 @@ def BaseNestedFieldSerializerFactory(
     many = kwargs.get("many", False)
     partial = kwargs.get("partial", None)
 
-    msg = (
+    assert not(
+        many and (accept_pk or accept_pk_only)
+    ), (
         "May not set both `many=True` and `accept_pk=True` "
         "or `accept_pk_only=True`"
         "(accept_pk and accept_pk_only applies to foreign key relation only)."
     )
-    assert not(many and (accept_pk or accept_pk_only)), msg
 
-    msg = "May not set both `accept_pk=True` and `accept_pk_only=True`"
-    assert not(accept_pk and accept_pk_only), msg
+    assert not(
+        accept_pk and accept_pk_only
+    ), "May not set both `accept_pk=True` and `accept_pk_only=True`"
+
+    assert not(
+        allow_remove_all and not many
+    ), (
+        "`allow_remove_all=True` can only be applied to many related "
+        "nested fields, ensure the kwarg `many=True` is set."
+    )
 
     def join_words(words, many='are', single='is'):
         word_list = ["`" + word + "`" for word in words]

--- a/django_restql/fields.py
+++ b/django_restql/fields.py
@@ -172,7 +172,7 @@ def BaseNestedFieldSerializerFactory(
                     return data
                 else:
                     msg = (
-                        "Usingi `%s` value on `%s` operation is disabled"
+                        "Using `%s` value on `%s` operation is disabled"
                         % (ALL_RELATED_OBJS, REMOVE)
                     )
                     raise ValidationError(msg, code="not_allowed")

--- a/django_restql/mixins.py
+++ b/django_restql/mixins.py
@@ -13,7 +13,7 @@ from rest_framework.serializers import (
 
 from .exceptions import FieldNotFound, QueryFormatError
 from .fields import (
-    BaseRESTQLNestedField, DynamicSerializerMethodField
+    ALL_RELATED_OBJS, BaseRESTQLNestedField, DynamicSerializerMethodField
 )
 from .operations import ADD, CREATE, REMOVE, UPDATE
 from .parser import QueryParser
@@ -932,7 +932,10 @@ class NestedUpdateMixin(BaseNestedMixin):
                     )
                 elif operation == REMOVE:
                     qs = nested_obj.all()
-                    qs.filter(pk__in=values[operation]).delete()
+                    if values[operation] == ALL_RELATED_OBJS:
+                        qs.delete()
+                    else:
+                        qs.filter(pk__in=values[operation]).delete()
                 elif operation == UPDATE:
                     self.bulk_update_many_to_one_related(
                         field,
@@ -972,6 +975,8 @@ class NestedUpdateMixin(BaseNestedMixin):
                     )
                 elif operation == REMOVE:
                     pks = values[operation]
+                    if pks == ALL_RELATED_OBJS:
+                        pks = nested_obj.all()
                     try:
                         nested_obj.remove(*pks)
                     except Exception as e:

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -2098,6 +2098,32 @@ class DataMutationTests(APITestCase):
             }
         )
 
+    def test_put_with__all__as_remove_operation_value(self):
+        url = reverse_lazy("wstudent-detail", args=[self.student.id])
+        data = {
+            "name": "Davinci",
+            "age": 23,
+            "course": {
+                "name": "Programming",
+                "code": "CS50",
+                "books": {"remove": "__all__"}
+            },
+            "phone_numbers": {"remove": "__all__"}
+        }
+        response = self.client.put(url, data, format="json")
+
+        self.assertEqual(
+            response.data,
+            {
+                'name': 'Davinci', 'age': 23,
+                'course': {
+                    'name': 'Programming', 'code': 'CS50',
+                    'books': []
+                },
+                'phone_numbers': []
+            }
+        )
+
     # **************** PATCH Tests ********************* #
 
     def test_patch_on_pk_nested_foreignkey_related_field(self):
@@ -2488,6 +2514,32 @@ class DataMutationTests(APITestCase):
                     {'number': '076750000', 'type': 'office', 'student': 1}
 
                 ]
+            }
+        )
+
+    def test_patch_with__all__as_remove_operation_value(self):
+        url = reverse_lazy("wstudent-detail", args=[self.student.id])
+        data = {
+            "name": "Davinci",
+            "age": 33,
+            "course": {
+                "name": "Programming",
+                "code": "CS50",
+                "books": {"remove": "__all__"}
+            },
+            "phone_numbers": {"remove": "__all__"}
+        }
+        response = self.client.patch(url, data, format="json")
+
+        self.assertEqual(
+            response.data,
+            {
+                'name': 'Davinci', 'age': 33,
+                'course': {
+                    'name': 'Programming', 'code': 'CS50',
+                    'books': []
+                },
+                'phone_numbers': []
             }
         )
 

--- a/tests/testapp/serializers.py
+++ b/tests/testapp/serializers.py
@@ -124,7 +124,7 @@ class WritableBookSerializer(DynamicFieldsMixin, NestedModelSerializer):
 
 
 class WritableCourseSerializer(DynamicFieldsMixin, NestedModelSerializer):
-    books = NestedField(WritableBookSerializer, many=True, required=False)
+    books = NestedField(WritableBookSerializer, many=True, required=False, allow_remove_all=True)
 
     class Meta:
         model = Course
@@ -152,7 +152,7 @@ class ReplaceableStudentWithAliasSerializer(DynamicFieldsMixin, NestedModelSeria
 
 class WritableStudentSerializer(DynamicFieldsMixin, NestedModelSerializer):
     course = NestedField(WritableCourseSerializer, allow_null=True, required=False)
-    phone_numbers = NestedField(PhoneSerializer, many=True, required=False)
+    phone_numbers = NestedField(PhoneSerializer, many=True, required=False, allow_remove_all=True)
 
     class Meta:
         model = Student


### PR DESCRIPTION
This adds the ability to remove all nested many related objects at once with just

```json
{
    "remove":  "__all__"
}
```

If `allow_remove_all=True` kwarg  is set when defining `NestedField`